### PR TITLE
Add a short explanation of the figured bass syntax.

### DIFF
--- a/poster-MEC-Salzburg-2020.tex
+++ b/poster-MEC-Salzburg-2020.tex
@@ -94,6 +94,9 @@ People accustomed to graphical user interfaces might need to learn a new way of 
 
     \lilypondfile{lily/figured-bass.ly}
 
+	A group of bass figures is delimited by `<' and `>', with the duration immediately appended.
+	Accidentals are entered by appending `+' for sharps, `-' for flats, or `!' for naturals,
+	immediately after each number.
 }
 
   \headerbox{Classical Music}{name=classical,column=1,span=1,below=figures}{


### PR DESCRIPTION
Mostly stolen directly from the LilyPond documentation, but with some changes to make it a little bit more compact.