### PR TITLE
Make "Note Entry" headings more descriptive.

### DIFF
--- a/poster-MEC-Salzburg-2020.tex
+++ b/poster-MEC-Salzburg-2020.tex
@@ -75,7 +75,7 @@ You do not write music by dragging notes from a graphical toolbar and placing th
 People accustomed to graphical user interfaces might need to learn a new way of working, but the results are definitely worth it!
   }
 
-\headerbox{Note Entry}{name=text,column=0,span=1,boxpadding=12pt,below=text}{
+\headerbox{Basic Note Entry}{name=text,column=0,span=1,boxpadding=12pt,below=text}{
 	Note entry is as easy as typing the note name and the duration.
 
 	\VerbatimInput{lily/note-entry.ly}
@@ -87,7 +87,7 @@ People accustomed to graphical user interfaces might need to learn a new way of 
 
 }
 
-\headerbox{Note Entry}{name=figures,column=1,span=1,boxpadding=12pt}{
+\headerbox{Figured Bass Entry}{name=figures,column=1,span=1,boxpadding=12pt}{
 	It is easy to add a figured bass.\vspace{1em}
 
 	\texttt{<7\textbackslash+ 4 2>8 <8> <7!>}\vspace{1em}


### PR DESCRIPTION
Should we make the `Note Entry` a little bit more descriptive? With more input examples, we'll end up with a handful of identically named `Note Entry` boxes. What about giving them unique names that adhere to a simple naming convention: must end with `Entry`. This PR renames the two `Note Entry` headings respectively `Basic Note Entry` and `Figured Bass Entry`.

Comments?